### PR TITLE
fix: filename case

### DIFF
--- a/UEAESKeyFinder.sln
+++ b/UEAESKeyFinder.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31105.61
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UEAesKeyFinder", "UEAesKeyFinder\UEAesKeyFinder.csproj", "{A184C3B9-EDEF-4BA5-96E6-207908AC9A46}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UEAESKeyFinder", "UEAESKeyFinder\UEAESKeyFinder.csproj", "{A184C3B9-EDEF-4BA5-96E6-207908AC9A46}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Building on Windows should work anyway, but if you try to build it on Linux (Docker) where the case does matter, it'll fail otherwise.

```
error MSB3202: The project file "/src/UEAesKeyFinder/UEAesKeyFinder.csproj" was not found. [/src/UEAESKeyFinder.sln]
```